### PR TITLE
Add quotes when args or flags have space

### DIFF
--- a/src/flag.ts
+++ b/src/flag.ts
@@ -11,16 +11,25 @@ export function flag(name: string) {
   }
 }
 
+export function spaceCheck(val: string) {
+  if(val.includes(' ')) {
+    let quoteChar = "\""
+    return quoteChar.concat(val, quoteChar)
+  } else {
+    return val
+  }
+}
+
 export default function(flags: Flags = {}) {
   return Object.keys(flags).reduce((retval, key) => {
     const value = flags[key];
     if(value === true) {
       return retval.concat(flag(key));
     } else if(typeof value === "string") {
-      return retval.concat([flag(key), value]);
+      return retval.concat([flag(key), spaceCheck(value)]);
     } else if(Array.isArray(value)) {
       return retval.concat(value.reduce((list, item) => {
-        return list.concat([flag(key), item]);
+        return list.concat([flag(key), spaceCheck(item)]);
       }, ([] as string[])));
     } else {
       return retval;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import exec from "./exec";
 import execSync from "./exec-sync";
 import execAll, { ExecAllOptions } from "./exec-all";
 import { JSONObject } from "parse-json-object";
-import flagsToArgs, { Flags } from "./flag";
+import flagsToArgs, { Flags, spaceCheck } from "./flag";
 
 export type SpawnOptions = {
   env?: NodeJS.ProcessEnv;
@@ -33,9 +33,10 @@ export type ExecResult = {
 export function getArgs(args: string | string[] = [], flags: Flags = {}) {
   let retval: string[] = [];
   if(typeof args === "string") {
-    retval.push(args);
+    retval.push(spaceCheck(args))
   } else {
-    retval = retval.concat(args);
+    const argsSpaceCheck = args.map(arg => spaceCheck(arg))
+    retval = retval.concat(argsSpaceCheck);
   }
   return retval.concat(flagsToArgs(flags));
 }

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -10,3 +10,25 @@ test("exec output", () => {
     }
   })).toBe("foo a b -c -d ok");
 });
+
+test("exec output space check 1", () => {
+  expect(commandToString({
+    command: "foo",
+    args: ["a", "b", "x y"],
+    flags: {
+      c: true,
+      d: ["ok", "boo mer"]
+    }
+  })).toBe("foo a b \"x y\" -c -d ok -d \"boo mer\"");
+});
+
+test("exec output space check 2", () => {
+  expect(commandToString({
+    command: "foo",
+    args: "x y",
+    flags: {
+      c: true,
+      d: "ok dawg"
+    }
+  })).toBe("foo \"x y\" -c -d \"ok dawg\"");
+});


### PR DESCRIPTION
Resolves #3 
When args or flags have spaces in them this adds quotes around the string. 
Added two tests as well.